### PR TITLE
Add csproj file to WspaceOpenGL project

### DIFF
--- a/WspaceOpenGL/WspaceOpenGL.csproj
+++ b/WspaceOpenGL/WspaceOpenGL.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="OpenTK" Version="3.2.0" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Fixes #3

Add a new .NET Core project file for the `WspaceOpenGL` project.

* Create `WspaceOpenGL/WspaceOpenGL.csproj` file
* Set `OutputType` to `Exe`
* Set `TargetFramework` to `netcoreapp3.1`
* Add `OpenTK` package reference with version `3.2.0`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/JoshGibsonUOH/WspaceOpenGL/issues/3?shareId=071b3d97-da8d-4178-af79-4186c0dca991).